### PR TITLE
Fixed recursion issue when there are more columns

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
   "author": "Joubel",
   "majorVersion": 1,
   "minorVersion": 8,
-  "patchVersion": 1,
+  "patchVersion": 2,
   "runnable": 1,
   "fullscreen": 0,
   "embedTypes": [

--- a/scripts/h5p-column.js
+++ b/scripts/h5p-column.js
@@ -437,8 +437,11 @@ H5P.Column = (function () {
       // Prevent target from sending event back down
       target.bubblingUpwards = true;
 
-      // Trigger event
-      target.trigger(eventName, event);
+      //Avoid potential recursion if several columns are in the same frame
+      if (target.libraryInfo.machineName != 'H5P.Column') {
+        // Trigger event 
+        target.trigger(eventName, event);
+      }
 
       // Reset
       target.bubblingUpwards = false;


### PR DESCRIPTION
If a module is using several columns, an infinite resize recursion can occur. This commit asserts that the target is not another column