### PR TITLE
Remove Twitter user feed from content type options

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "author": "Joubel",
   "majorVersion": 1,
-  "minorVersion": 13,
-  "patchVersion": 1,
+  "minorVersion": 14,
+  "patchVersion": 0,
   "runnable": 1,
   "fullscreen": 0,
   "embedTypes": [

--- a/semantics.json
+++ b/semantics.json
@@ -48,7 +48,6 @@
             "H5P.Summary 1.10",
             "H5P.Timeline 1.1",
             "H5P.TrueFalse 1.6",
-            "H5P.TwitterUserFeed 1.0",
             "H5P.Video 1.5"
           ]
         },

--- a/upgrades.js
+++ b/upgrades.js
@@ -40,8 +40,42 @@ H5PUpgrades['H5P.Column'] = (function () {
 
         // Done
         finished(null, parameters);
-      }
+      },
 
+      /**
+       * Asynchronous content upgrade hook.
+       * Upgrades content parameters to support Column 1.14.
+       *
+       * - Converts H5P.TwitterUserFeed to H5P.AdvancedText
+       *
+       * @param {Object} parameters
+       * @param {function} finished
+       */
+      14: function (parameters, finished, extras) {
+
+        if (parameters && parameters.content) {
+
+          debugger
+
+          // Go through content
+          for (var i = 0; i < parameters.content.length; i++) {
+            if (parameters.content[i] && parameters.content[i].content) {
+
+              const content = parameters.content[i].content;
+              if (content.library && content.library.split(' ')[0] === 'H5P.TwitterUserFeed') {
+
+                content.library = 'H5P.AdvancedText 1.1';
+
+                content.params = content.params || {};
+                content.params.text = '<p>Twitter changed their API and user feeds can no longer be displayed here.</p>';
+              }
+            }
+          }
+        }
+
+        // Done
+        finished(null, parameters, extras);
+      }
     }
   };
 })();


### PR DESCRIPTION
The Twitter user feed content type does not work anymore due to API changed. When merged in, this pull request will remove the content type from content type options and replace existing content with a message to the user.