### PR TITLE
Set activity started only if Column is main content

### DIFF
--- a/scripts/h5p-column.js
+++ b/scripts/h5p-column.js
@@ -488,7 +488,10 @@ H5P.Column = (function (EventDispatcher) {
       createHTML();
     }
 
-    self.setActivityStarted();
+    // Expect parent to set activity started when Column is actually shown
+    if (typeof self.isRoot === 'function' && self.isRoot()) {
+      self.setActivityStarted();
+    }
   }
 
   Column.prototype = Object.create(EventDispatcher.prototype);


### PR DESCRIPTION
If Column is supposed to be used as subcontent (e.g. in https://github.com/h5p/h5p-accordion/pull/41), it should not call `setActivityStarted()` on its own but leave that to the parent content type (just like other compound content types do). Otherwise, the xAPI `attempted` statement may be triggered prematurely and report a wrong duration in the `completed` statement.