### PR TITLE
Hide fullscreen button for video/DQ of all Columns

### DIFF
--- a/styles/h5p-column.css
+++ b/styles/h5p-column.css
@@ -82,7 +82,7 @@
 }
 
 /* Remove fullscreen for video tags and DQ */
-.h5p-interactive-book video::-webkit-media-controls-fullscreen-button,
-.h5p-interactive-book .h5p-my-fullscreen-button-enter {
+.h5p-column-content  video::-webkit-media-controls-fullscreen-button,
+.h5p-column-content  .h5p-my-fullscreen-button-enter {
   display: none;
 }


### PR DESCRIPTION
When merged in, the fullscreen button of "Video" instances and "Drag Question" instances will be hidden for _all_ "Column" instances, not only for Interactive Book.

Background: The fullscreen button on Column subcontent can create a weird user experience. While sending "Video" to fullscreen seems to work on Chrome, iOS is known to cause trouble and only sending some subcontent to fullscreen may be confusing at times. Sending "Drag Question" to fullscreen even crashes.

The current implementation feels like a hot fix And if the change that's done was limited to Interactive Book intentionally, one would expect those extra CSS classes in the code of Interactive Book instead, not here in Column.