### PR TITLE
Update h5p-column.js

### DIFF
--- a/scripts/h5p-column.js
+++ b/scripts/h5p-column.js
@@ -66,12 +66,17 @@ H5P.Column = (function (EventDispatcher) {
      *
      * @private
      * @param {number} taskIndex
+     * @param {string} library
      * @return {function} xAPI event handler
      */
-    var trackScoring = function (taskIndex) {
+    var trackScoring = function (taskIndex, library) {
       return function (event) {
         if (event.getScore() === null) {
           return; // Skip, not relevant
+        }
+
+        if (library === 'H5P.SingleChoiceSet' && event.getVerb() === 'answered') {
+          return; // Ignore answered event
         }
 
         if (tasksResultEvent[taskIndex] === undefined) {
@@ -127,7 +132,7 @@ H5P.Column = (function (EventDispatcher) {
       if (Column.isTask(instance)) {
         // Tasks requires completion
 
-        instance.on('xAPI', trackScoring(numTasks));
+        instance.on('xAPI', trackScoring(numTasks, library));
         numTasks++;
       }
 


### PR DESCRIPTION
If `Single Choice Set` is the only content in the `Column` or it is the last one that has not been answered yet, then answering each of the questions will make that `Column` send a `completed` event with **incorrect score**. This is because the check only makes sure that event has score and thus `answered` **xAPI** event is considered suitable.

The change checks for a specific library and ignores `answered` events.